### PR TITLE
Improvements to breadcrumbs + settings dropdown

### DIFF
--- a/src/Components/DropdownSettings.jsx
+++ b/src/Components/DropdownSettings.jsx
@@ -1,0 +1,66 @@
+import {useEffect, useState} from 'react';
+import {EllipsisVerticalIcon} from '@heroicons/react/20/solid';
+import PropTypes from 'prop-types';
+
+export default function DropdownSettings({items}) {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    // setup settings dropdown click events
+    const onClick = () => {
+      setIsVisible(false);
+    };
+    document.addEventListener('click', onClick);
+
+    return () => {
+      document.removeEventListener('click', onClick);
+    };
+  }, []);
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={e => {
+          e.stopPropagation();
+          setIsVisible(v => !v);
+        }}
+        className="inline-flex items-center p-2 text-sm font-medium text-center
+               text-gray-900 bg-white rounded-lg hover:bg-gray-100 focus:ring-4
+               focus:outline-none dark:text-white focus:ring-gray-50 dark:bg-gray-700
+               dark:hover:bg-gray-600 dark:focus:ring-gray-500"
+      >
+        <EllipsisVerticalIcon className="min-w-[1.25rem] h-5" />
+      </button>
+      <ul
+        className={`absolute z-10 right-0 top-full w-max bg-white divide-y divide-gray-100 dark:divide-gray-500 rounded-lg shadow
+                   py-2 text-sm text-gray-700 dark:text-gray-200 dark:bg-gray-600 ${
+                     isVisible ? '' : 'hidden'
+                   }`}
+      >
+        {items.map((item, i) => (
+          <li key={i}>
+            <button
+              type="button"
+              className="flex w-full gap-2 px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-500 dark:hover:text-white"
+            >
+              <span className="min-w-[1.25rem] h-5 text-red-700 dark:text-red-500">
+                {item.icon}
+              </span>
+              <span>{item.text}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+DropdownSettings.propTypes = {
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      icon: PropTypes.node.isRequired,
+      text: PropTypes.string.isRequired,
+    })
+  ),
+};

--- a/src/Components/Tailwind/Breadcrumbs.tsx
+++ b/src/Components/Tailwind/Breadcrumbs.tsx
@@ -1,5 +1,5 @@
-import {CalendarIcon, ChevronRightIcon} from '@heroicons/react/24/solid';
-import Typography from './Typography';
+import {CalendarIcon, UserCircleIcon} from '@heroicons/react/24/solid';
+import IconFeather from '../Icons/Feather';
 
 interface BreadcrumbsProps {
   routeNames: string[];
@@ -7,49 +7,41 @@ interface BreadcrumbsProps {
   className?: HTMLDivElement['className'];
 }
 
-const defaultParentClassName: HTMLDivElement['className'] = 'flex text-gray-700 items-center w-fit';
-
-export const Breadcrumbs = ({
-  routeNames = [],
-  routeHandlers = [],
-  className = '',
-}: BreadcrumbsProps) => {
-  const parentClassName = defaultParentClassName + ' ' + className;
-
+export const Breadcrumbs = ({routeNames = [], routeHandlers = []}: BreadcrumbsProps) => {
   return (
-    <div className={parentClassName} aria-label="Breadcrumb">
-      <CalendarIcon className="w-5 h-5 mr-1 text-primary" />
-
-      <ol className="inline-flex items-center md:space-x-3">
+    <div className="flex" aria-label="Breadcrumb">
+      <ol className="flex flex-wrap gap-3 items-center">
         {routeNames.map((item, idx) => {
           const routeHandler: (() => void) | null =
             idx >= 0 && idx < routeHandlers.length ? routeHandlers[idx] : null;
 
-          return (
-            <li className="inline-flex items-center" key={idx}>
-              <>
-                {idx > 0 && <ChevronRightIcon className="w-4 h-4 text-gray-600 dark:text-white" />}
+          const children = (
+            <>
+              {idx === 0 && <CalendarIcon className="w-5 h-5 min-w-[1.25rem] mr-1 text-primary" />}
+              {idx === 1 && <IconFeather className="w-5 h-5 min-w-[1.25rem] mr-1 text-primary" />}
+              {idx === 2 && (
+                <UserCircleIcon className="w-5 h-5 min-w-[1.25rem] mr-1 text-primary" />
+              )}
+              <span>{item}</span>
+            </>
+          );
 
-                {routeHandler ? (
-                  <button onClick={routeHandler}>
-                    <Typography
-                      variant="body3"
-                      className="items-center text-gray-800 hover:text-blue-600 dark:text-gray-400 dark:hover:text-white
-                px-2 py-2 border border-gray-200 rounded-lg bg-gray-50 dark:bg-gray-800 dark:border-gray-700"
-                    >
-                      {item}
-                    </Typography>
-                  </button>
-                ) : (
-                  <Typography
-                    variant="body3"
-                    className="items-center text-gray-800 hover:text-blue-600 dark:text-gray-400 dark:hover:text-white
-              px-2 py-2 border border-gray-200 rounded-lg bg-gray-50 dark:bg-gray-800 dark:border-gray-700"
-                  >
-                    {item}
-                  </Typography>
-                )}
-              </>
+          return (
+            <li className="flex items-center" key={idx}>
+              {routeHandler && (
+                <button
+                  onClick={routeHandler}
+                  className="flex gap-1 text-sm font-medium text-gray-700 text-left
+                             hover:text-blue-600 dark:text-gray-400 dark:hover:text-white"
+                >
+                  {children}
+                </button>
+              )}
+              {!routeHandler && (
+                <div className="flex gap-1 items-center text-sm font-medium text-gray-500 dark:text-gray-400">
+                  {children}
+                </div>
+              )}
             </li>
           );
         })}

--- a/src/pages/Events/EventPage.jsx
+++ b/src/pages/Events/EventPage.jsx
@@ -1,7 +1,8 @@
 import {useEffect, useState} from 'react';
 import {useLocation, useNavigate, useParams} from 'react-router-dom';
 import {UserGroupIcon} from '@heroicons/react/20/solid';
-import {ShieldCheckIcon} from '@heroicons/react/24/solid';
+import {ShieldCheckIcon, TrashIcon} from '@heroicons/react/24/solid';
+import DropdownSettings from '../../Components/DropdownSettings';
 import IconFeather from '../../Components/Icons/Feather';
 import {Typography} from '../../Components/Tailwind';
 import {Breadcrumbs} from '../../Components/Tailwind/Breadcrumbs';
@@ -198,8 +199,11 @@ const EventPage = () => {
 
   return (
     <div className="px-6 pt-1">
-      <div className="flex justify-between">
-        <Breadcrumbs className="" routeNames={[event.title]} routeHandlers={[null]} />
+      <div className="flex flex-row w-100 items-start justify-between gap-4">
+        <div className="pt-2">
+          <Breadcrumbs routeNames={[event.title]} routeHandlers={[null]} />
+        </div>
+        <DropdownSettings items={[{icon: <TrashIcon />, text: 'Delete event'}]} />
       </div>
       <div className="mt-6 flex flex-col gap-4">
         {isLoading && <LoadingIndicator className="mt-20" />}

--- a/src/pages/Events/RegFormPage.tsx
+++ b/src/pages/Events/RegFormPage.tsx
@@ -1,7 +1,7 @@
 import {useEffect, useMemo, useState} from 'react';
 import {useNavigate, useParams} from 'react-router-dom';
-import {ShieldCheckIcon} from '@heroicons/react/20/solid';
-import {Typography} from '../../Components/Tailwind';
+import {ShieldCheckIcon, TrashIcon} from '@heroicons/react/20/solid';
+import DropdownSettings from '../../Components/DropdownSettings';
 import {Breadcrumbs} from '../../Components/Tailwind/Breadcrumbs';
 import {LoadingIndicator} from '../../Components/Tailwind/LoadingIndicator';
 import Table, {rowProps} from '../../Components/Tailwind/Table';
@@ -116,18 +116,22 @@ const RegistrationFormPage = () => {
   };
 
   return (
-    <div className="mx-auto w-full h-full justify-center align-center mt-3">
+    <div className="px-6 pt-1">
       {eventData && (
         <>
-          <div className="flex flex-row w-100 items-center justify-between">
-            <Breadcrumbs
-              className="ml-2"
-              routeNames={[eventData.event?.title, eventData.label]}
-              routeHandlers={[navigateBack, null]}
+          <div className="flex flex-row w-100 items-start justify-between gap-4">
+            <div className="pt-2">
+              <Breadcrumbs
+                routeNames={[eventData.event?.title, eventData.label]}
+                routeHandlers={[navigateBack, null]}
+              />
+            </div>
+            <DropdownSettings
+              items={[
+                {icon: <TrashIcon />, text: 'Delete event'},
+                {icon: <TrashIcon />, text: 'Delete registration form'},
+              ]}
             />
-            <Typography variant="body3" className="mr-2">
-              {eventData.event?.date}
-            </Typography>
           </div>
           <div className="mt-6">
             {isLoading && <LoadingIndicator className="mt-20" />}
@@ -136,7 +140,6 @@ const RegistrationFormPage = () => {
                 columnLabels={['Attendees']}
                 searchColIdx={0}
                 rows={tableRows}
-                className="w-5/6 m-auto mt-6"
                 RightIcon={ShieldCheckIcon}
               />
             )}


### PR DESCRIPTION
- visual improvements for breadcrumbs - adds regform to the breadcrumbs, better handling of long text
- settings dropdown on event/regform pages (+ eventually on participant page?)

![image](https://github.com/monkin77/cern-indico-check-in/assets/8739637/e88c09c8-7b39-453a-8757-8a9013285429)
![image](https://github.com/monkin77/cern-indico-check-in/assets/8739637/b12115a9-9270-4826-bdcb-b54dee8cbfd1)
![image](https://github.com/monkin77/cern-indico-check-in/assets/8739637/1729c182-ee57-4729-8eb0-89f7a3db1138)

dark mode:

![image](https://github.com/monkin77/cern-indico-check-in/assets/8739637/d40f49b7-5b43-40a9-91d7-89381379159b)
![image](https://github.com/monkin77/cern-indico-check-in/assets/8739637/71b335b7-96b5-4dbd-8d6c-33dbc29c07bb)
